### PR TITLE
Add Support to PowerShell Core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,8 @@ A library for running Windows PowerShell scripts
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Use PowerShell Core instead of Windows Powershell.
+core = []
+
 [dependencies]

--- a/examples/hello/main.rs
+++ b/examples/hello/main.rs
@@ -1,0 +1,14 @@
+extern crate powershell_script;
+
+/// Print 'Hello' to console.
+fn main() {
+    let create_shortcut = include_str!("script.ps1");
+    match powershell_script::run(create_shortcut, false) {
+        Ok(output) => {
+            eprint!("{}", output);
+        }
+        Err(e) => {
+            println!("Error: {}", e);
+        }
+    }
+}

--- a/examples/hello/main.rs
+++ b/examples/hello/main.rs
@@ -2,8 +2,8 @@ extern crate powershell_script;
 
 /// Print 'Hello' to console.
 fn main() {
-    let create_shortcut = include_str!("script.ps1");
-    match powershell_script::run(create_shortcut, false) {
+    let hello = include_str!("script.ps1");
+    match powershell_script::run(hello, false) {
         Ok(output) => {
             eprint!("{}", output);
         }

--- a/examples/hello/script.ps1
+++ b/examples/hello/script.ps1
@@ -1,0 +1,1 @@
+echo "Hello"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,14 @@ type Result<T> = std::result::Result<T, PsError>;
 /// ## Panics
 /// If there is an error retrieving a handle to `stdin` in the child process.
 pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
+    #[cfg(all(not(feature = "core"), windows))]      
+    // Windows PowerShell
     let mut cmd = Command::new("PowerShell");
+
+    #[cfg(any(feature = "core", not(windows)))]    
+    // PowerShell Core
+    let mut cmd = Command::new("pwsh");
+
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,11 @@ type Result<T> = std::result::Result<T, PsError>;
 /// ## Panics
 /// If there is an error retrieving a handle to `stdin` in the child process.
 pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
-    #[cfg(all(not(feature = "core"), windows))]      
+    #[cfg(all(not(feature = "core"), windows))]
     // Windows PowerShell
     let mut cmd = Command::new("PowerShell");
 
-    #[cfg(any(feature = "core", not(windows)))]    
+    #[cfg(any(feature = "core", not(windows)))]
     // PowerShell Core
     let mut cmd = Command::new("pwsh");
 


### PR DESCRIPTION
Hello, this PR adds support for PowerShell Core, so it is possible to run scripts on Mac and Linux as well.

I also added a feature called `core`, to use PowerShell Core on Windows instead of the system default.