### PR TITLE
Launch powershell scripts with `-NoProfile`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut process = cmd.args(&["-Command", "-"]).spawn()?;
+    let mut process = cmd.args(&["-NoProfile", "-Command", "-"]).spawn()?;
     let stdin = process.stdin.as_mut().ok_or(PsError::ChildStdinNotFound)?;
 
     for line in script.lines() {
@@ -111,7 +111,7 @@ pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
 /// fn main() {
 ///     let script = r#"echo "hello world""#;
 ///     let output = powershell_script::run(script, false).unwrap();
-///     assert_eq!(output.stdout().unwrap(), "hello world\r\n");
+///     assert_eq!(output.stdout().unwrap().trim(), "hello world");
 /// }
 /// ```
 pub fn run(script: &str, print_commands: bool) -> Result<Output> {

--- a/tests/hello/main.rs
+++ b/tests/hello/main.rs
@@ -1,8 +1,13 @@
 extern crate powershell_script;
 
+#[cfg(windows)]
+const LINE_ENDING: &'static str = "\r\n";
+#[cfg(not(windows))]
+const LINE_ENDING: &'static str = "\n";
+
 #[test]
 fn main() {
     let script = r#"echo "hello world""#;
     let output = powershell_script::run(script, false).unwrap();
-    assert_eq!(output.stdout().unwrap(), "hello world\r\n");
+    assert_eq!(output.stdout().unwrap(), format!("hello world{}", LINE_ENDING));
 }


### PR DESCRIPTION
This will ensure better cross platform compatability as it guarentees
that no environment specifc scripts are loaded.

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.2#the-noprofile-parameter