### PR TITLE
Add 'NonInteractive' flag to pwsh run

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut process = cmd.args(&["-NoProfile", "-Command", "-"]).spawn()?;
+    let mut process = cmd.args(&["-NoProfile", "-NonInteractive", "-Command", "-"]).spawn()?;
     let stdin = process.stdin.as_mut().ok_or(PsError::ChildStdinNotFound)?;
 
     for line in script.lines() {


### PR DESCRIPTION
`NonInteractive` tells powershell not to prompt a non-interactive prompt
to the user. This can be used by commands we run which under powershell
to determine if they should prompt the user or not.