### PR TITLE
Make powershell window invisible during execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn run_raw(script: &str, print_commands: bool) -> Result<ProcessOutput> {
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut process = cmd.args(&["-NoProfile", "-Command", "-"]).spawn()?;
+    let mut process = cmd.args(&["-NoProfile", "-WindowStyle", "Hidden", "-Command", "-"]).spawn()?;
     let stdin = process.stdin.as_mut().ok_or(PsError::ChildStdinNotFound)?;
 
     for line in script.lines() {


### PR DESCRIPTION
This change makes the PowerShell window invisible during script execution, making the crate less annoying for the software's end users.